### PR TITLE
[Enhancement] add analyze query tool

### DIFF
--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -302,8 +302,7 @@ def write_query(query: Annotated[str, Field(description="SQL to execute")]) -> s
         if cursor:
             cursor.close()
 
-def analyze_query(uuid: Annotated[str, Field(description="UUID is a string composed of 32 hexadecimal digits, typically formatted as 8-4-4-4-12")], 
-                                            sql: Annotated[str, Field(description="SQL statements are used to operate database, typically beginning with keywords such as SELECT, INSERT, UPDATE, DELETE, etc.")]) -> str:
+def analyze_query(uuid: Annotated[str, Field(description="Query ID, formatted as 8-4-4-4-12")], sql: Annotated[str, Field(description="Query SQL")]) -> str:
     if uuid:
         return read_query(f"ANALYZE PROFILE FROM '{uuid}'")
     elif sql:

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -28,7 +28,6 @@ import mysql.connector
 import pandas as pd
 import plotly.express as px
 import base64
-import re
 
 mcp = FastMCP('mcp-server-starrocks')
 

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -310,7 +310,7 @@ def analyze_query(query: Annotated[str, Field(description="Analyze query via pro
     elif query.lstrip().lower().startswith(("select", "insert")): # input is query sql, only support SELECT and INSERT type SQL
         return read_query(f"EXPLAIN ANALYZE {query}")
     else:
-        return f"Failed to analyze the query, the reasons maybe: 1.not a standard format uuid query id; 2.only support SELECT and INSERT type SQL."
+        return f"Failed to analyze the query, the reasons maybe: 1.query id not a standard uuid format; 2.only support SELECT and INSERT type SQL."
 
 SR_PROC_DESC = '''
 Internal information exposed by StarRocks similar to linux /proc, following are some common paths:

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -302,7 +302,7 @@ def write_query(query: Annotated[str, Field(description="SQL to execute")]) -> s
         if cursor:
             cursor.close()
 
-def analyze_query(uuid: Annotated[str, Field(description="Query ID, formatted as 8-4-4-4-12")], sql: Annotated[str, Field(description="Query SQL")]) -> str:
+def analyze_query(uuid: Annotated[str, Field(description="Query ID, a string composed of 32 hexadecimal digits formatted as 8-4-4-4-12")], sql: Annotated[str, Field(description="Query SQL")]) -> str:
     if uuid:
         return read_query(f"ANALYZE PROFILE FROM '{uuid}'")
     elif sql:

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -302,17 +302,14 @@ def write_query(query: Annotated[str, Field(description="SQL to execute")]) -> s
         if cursor:
             cursor.close()
 
-def analyze_query(query: Annotated[str, Field(description="Analyze query via profile")]) -> str:
-    # check input's query id is standard uuid format or not
-    pattern_uuid = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
-    # check input's query sql is SELECT and INSERT INTO type SQL or not
-    pattern_sql = re.compile(r'^\s*(SELECT|INSERT\s+INTO)', re.IGNORECASE)
-    if pattern_uuid.match(query): # input is query id
-        return read_query(f"ANALYZE PROFILE FROM '{query}'")
-    elif pattern_sql.match(query): # input is query sql
-        return read_query(f"EXPLAIN ANALYZE {query}")
+def analyze_query(uuid: Annotated[str, Field(description="UUID is a string composed of 32 hexadecimal digits, typically formatted as 8-4-4-4-12")], 
+                                            sql: Annotated[str, Field(description="SQL statements are used to operate database, typically beginning with keywords such as SELECT, INSERT, UPDATE, DELETE, etc.")]) -> str:
+    if uuid:
+        return read_query(f"ANALYZE PROFILE FROM '{uuid}'")
+    elif sql:
+        return read_query(f"EXPLAIN ANALYZE {sql}")
     else:
-        return f"Failed to analyze query, the reasons maybe: 1.query id is not standard uuid format; 2.only support SELECT and INSERT INTO type SQL."
+        return f"Failed to analyze query, the reasons maybe: 1.query id is not standard uuid format; 2.the SQL statement have spelling error."
 
 
 SR_PROC_DESC = '''

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -303,14 +303,17 @@ def write_query(query: Annotated[str, Field(description="SQL to execute")]) -> s
             cursor.close()
 
 def analyze_query(query: Annotated[str, Field(description="Analyze query via profile")]) -> str:
-    # check input is standard uuid format or not
-    regex = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
-    if regex.match(query): # input is query id, standard uuid format
+    # check input's query id is standard uuid format or not
+    pattern_uuid = re.compile(r'^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$')
+    # check input's query sql is SELECT and INSERT INTO type SQL or not
+    pattern_sql = re.compile(r'^\s*(SELECT|INSERT\s+INTO)', re.IGNORECASE)
+    if pattern_uuid.match(query): # input is query id
         return read_query(f"ANALYZE PROFILE FROM '{query}'")
-    elif query.lstrip().lower().startswith(("select", "insert")): # input is query sql, only support SELECT and INSERT type SQL
+    elif pattern_sql.match(query): # input is query sql
         return read_query(f"EXPLAIN ANALYZE {query}")
     else:
-        return f"Failed to analyze the query, the reasons maybe: 1.query id not a standard uuid format; 2.only support SELECT and INSERT type SQL."
+        return f"Failed to analyze query, the reasons maybe: 1.query id is not standard uuid format; 2.only support SELECT and INSERT INTO type SQL."
+
 
 SR_PROC_DESC = '''
 Internal information exposed by StarRocks similar to linux /proc, following are some common paths:


### PR DESCRIPTION
## Why I'm doing:
current tool in mcp could not analyze query, like:
![5](https://github.com/user-attachments/assets/66f75b90-5ead-4c1a-81bc-1ce679bddd7d)

## What I'm doing:
add a tool(named as `analyze_query`) to analyze query when encounter big query or slow query. 
input: query id or query sql

**1.query id**
![1](https://github.com/user-attachments/assets/3d0d3d43-7b7f-4e42-9ea7-7cbe94484798)

**2.query sql**
![2](https://github.com/user-attachments/assets/9be4c884-1995-493d-ab73-a21c060e08cb)
