### PR TITLE
Fix BIGINT precision loss in structured_content JSON serialization

### DIFF
--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -27,6 +27,26 @@ from adbc_driver_manager import Error as adbcError
 import pandas as pd
 
 
+# JavaScript Number.MAX_SAFE_INTEGER (2^53 - 1)
+# Integers beyond this range lose precision in JSON when parsed by JavaScript clients.
+MAX_SAFE_INTEGER = 2**53 - 1
+
+
+def _safe_json_value(v):
+    """Convert integers outside JavaScript's safe integer range to strings.
+
+    JavaScript ``Number`` is IEEE 754 double-precision (53-bit mantissa).
+    Integers with absolute value larger than ``2**53 - 1`` silently lose
+    precision when a JS client parses the JSON.  Converting them to strings
+    preserves the exact value.
+    """
+    if isinstance(v, int) and not isinstance(v, bool) and (
+        v > MAX_SAFE_INTEGER or v < -MAX_SAFE_INTEGER
+    ):
+        return str(v)
+    return v
+
+
 @dataclass
 class ResultSet:
     """Database query result set."""
@@ -79,7 +99,9 @@ class ResultSet:
         }
         if self.column_names is not None:
             ret["column_names"] = self.column_names
-            ret["rows"] = self.rows
+            ret["rows"] = [
+                [_safe_json_value(v) for v in row] for row in self.rows
+            ]
         if self.rows_affected is not None:
             ret["rows_affected"] = self.rows_affected
         if self.error_message:

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -21,11 +21,13 @@ os.environ.pop('STARROCKS_FE_ARROW_FLIGHT_SQL_PORT', None)  # Force MySQL mode f
 os.environ.pop('STARROCKS_DB', None)  # No default database
 
 from src.mcp_server_starrocks.db_client import (
-    DBClient, 
-    ResultSet, 
-    get_db_client, 
+    DBClient,
+    ResultSet,
+    get_db_client,
     reset_db_connections,
-    parse_connection_url
+    parse_connection_url,
+    _safe_json_value,
+    MAX_SAFE_INTEGER,
 )
 
 
@@ -617,6 +619,131 @@ class TestResultSet:
         assert result.column_names is None
         assert result.rows is None
         assert result.error_message is None
+
+
+class TestSafeJsonValue:
+    """Test cases for _safe_json_value helper and ResultSet.to_dict() bigint handling."""
+
+    def test_small_integers_unchanged(self):
+        """Integers within safe range should be returned as-is."""
+        assert _safe_json_value(0) == 0
+        assert _safe_json_value(1) == 1
+        assert _safe_json_value(-1) == -1
+        assert _safe_json_value(42) == 42
+        assert _safe_json_value(MAX_SAFE_INTEGER) == MAX_SAFE_INTEGER
+        assert _safe_json_value(-MAX_SAFE_INTEGER) == -MAX_SAFE_INTEGER
+
+    def test_large_positive_integers_become_strings(self):
+        """Integers above MAX_SAFE_INTEGER should become strings."""
+        val = MAX_SAFE_INTEGER + 1  # 2^53
+        assert _safe_json_value(val) == str(val)
+
+        val = MAX_SAFE_INTEGER + 2  # 2^53 + 1
+        assert _safe_json_value(val) == str(val)
+
+        val = 55309298709016489
+        assert _safe_json_value(val) == "55309298709016489"
+
+    def test_large_negative_integers_become_strings(self):
+        """Integers below -MAX_SAFE_INTEGER should become strings."""
+        val = -MAX_SAFE_INTEGER - 1
+        assert _safe_json_value(val) == str(val)
+
+        val = -7108510333361982070
+        assert _safe_json_value(val) == "-7108510333361982070"
+
+    def test_non_integer_types_unchanged(self):
+        """Non-integer types should pass through unmodified."""
+        assert _safe_json_value("hello") == "hello"
+        assert _safe_json_value(3.14) == 3.14
+        assert _safe_json_value(None) is None
+        assert _safe_json_value([1, 2]) == [1, 2]
+
+    def test_booleans_not_converted(self):
+        """Booleans (subclass of int in Python) must not be stringified."""
+        assert _safe_json_value(True) is True
+        assert _safe_json_value(False) is False
+
+    def test_boundary_values(self):
+        """Test exact boundary: MAX_SAFE_INTEGER is safe, MAX_SAFE_INTEGER+1 is not."""
+        assert _safe_json_value(MAX_SAFE_INTEGER) == MAX_SAFE_INTEGER
+        assert isinstance(_safe_json_value(MAX_SAFE_INTEGER), int)
+
+        assert _safe_json_value(MAX_SAFE_INTEGER + 1) == str(MAX_SAFE_INTEGER + 1)
+        assert isinstance(_safe_json_value(MAX_SAFE_INTEGER + 1), str)
+
+        assert _safe_json_value(-MAX_SAFE_INTEGER) == -MAX_SAFE_INTEGER
+        assert isinstance(_safe_json_value(-MAX_SAFE_INTEGER), int)
+
+        assert _safe_json_value(-MAX_SAFE_INTEGER - 1) == str(-MAX_SAFE_INTEGER - 1)
+        assert isinstance(_safe_json_value(-MAX_SAFE_INTEGER - 1), str)
+
+    def test_to_dict_converts_large_integers_in_rows(self):
+        """ResultSet.to_dict() should convert large ints in rows to strings."""
+        large_val = 9007199254740993  # 2^53 + 1
+        neg_large = -7108510333361982070
+        safe_val = 42
+
+        result = ResultSet(
+            success=True,
+            column_names=['id', 'big_val', 'neg_val'],
+            rows=[[safe_val, large_val, neg_large]],
+            execution_time=0.1,
+        )
+
+        d = result.to_dict()
+        assert d["rows"] == [[42, str(large_val), str(neg_large)]]
+
+    def test_to_dict_preserves_safe_integers(self):
+        """ResultSet.to_dict() should keep safe integers as ints."""
+        result = ResultSet(
+            success=True,
+            column_names=['a', 'b'],
+            rows=[[1, MAX_SAFE_INTEGER], [-1, -MAX_SAFE_INTEGER]],
+            execution_time=0.05,
+        )
+
+        d = result.to_dict()
+        assert d["rows"] == [[1, MAX_SAFE_INTEGER], [-1, -MAX_SAFE_INTEGER]]
+        # Verify they are still ints, not strings
+        assert isinstance(d["rows"][0][1], int)
+        assert isinstance(d["rows"][1][1], int)
+
+    def test_to_dict_mixed_types_in_rows(self):
+        """ResultSet.to_dict() handles rows with mixed types correctly."""
+        large_val = 2**53 + 100
+        result = ResultSet(
+            success=True,
+            column_names=['id', 'name', 'big', 'flag', 'ratio'],
+            rows=[[1, 'hello', large_val, True, 3.14]],
+            execution_time=0.1,
+        )
+
+        d = result.to_dict()
+        row = d["rows"][0]
+        assert row[0] == 1          # safe int unchanged
+        assert row[1] == 'hello'    # string unchanged
+        assert row[2] == str(large_val)  # large int -> string
+        assert row[3] is True       # bool unchanged
+        assert row[4] == 3.14       # float unchanged
+
+    def test_to_dict_does_not_mutate_original_rows(self):
+        """to_dict() must not modify the original ResultSet.rows."""
+        large_val = 2**53 + 1
+        original_rows = [[1, large_val]]
+        result = ResultSet(
+            success=True,
+            column_names=['id', 'big'],
+            rows=original_rows,
+            execution_time=0.1,
+        )
+
+        d = result.to_dict()
+        # The dict should have the string version
+        assert d["rows"][0][1] == str(large_val)
+        # But original rows should be untouched
+        assert result.rows[0][1] == large_val
+        assert isinstance(result.rows[0][1], int)
 
 
 class TestParseConnectionUrl:


### PR DESCRIPTION
## Summary

- Convert integers exceeding JavaScript's `Number.MAX_SAFE_INTEGER` (2^53 − 1) to strings in `ResultSet.to_dict()`, preventing silent rounding when MCP clients (JavaScript/Node.js) parse the JSON
- Add `_safe_json_value()` helper that only converts integers outside the safe range — booleans, floats, strings, and safe-range integers pass through unchanged
- Add 10 unit tests covering boundary values, mixed types, negative values, boolean exclusion, and immutability of original rows

Fixes #36

## Test plan

- [x] All 10 new `TestSafeJsonValue` tests pass
- [x] Existing `TestDummyMode`, `TestParseConnectionUrl`, `TestResultSet` tests unaffected
- [x] Integration test with real StarRocks: `SELECT 9007199254740993` returns string `"9007199254740993"` in `structured_content` and exact int `9007199254740993` in text content