### PR TITLE
Add macOS Keychain-backed password lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ You can configure StarRocks connection using either individual environment varia
 - `STARROCKS_PORT`: (Optional) MySQL protocol port of the StarRocks FE service. Defaults to `9030`.
 - `STARROCKS_USER`: (Optional) StarRocks username. Defaults to `root`.
 - `STARROCKS_PASSWORD`: (Optional) StarRocks password. Defaults to empty string.
+- `STARROCKS_PASSWORD_KEYCHAIN_SERVICE`: (Optional, macOS only) Generic password service name to use when reading the password from Keychain. This is only used when no explicit password is provided via `STARROCKS_PASSWORD` or `STARROCKS_URL`.
+- `STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT`: (Optional, macOS only) Generic password account name to use when reading the password from Keychain. Defaults to the resolved StarRocks user.
 - `STARROCKS_DB`: (Optional) Default database to use if not specified in tool arguments or resource URIs. If set, the connection will attempt to `USE` this database. Tools like `table_overview` and `db_overview` will use this if the database part is omitted in their arguments. Defaults to empty (no default database).
 
 **Option 2: Connection URL (takes precedence over individual variables)**
@@ -187,6 +189,33 @@ You can configure StarRocks connection using either individual environment varia
   - `root:mypass@localhost:9030/test_db`
   - `mysql://admin:secret@db.example.com:9030/production`  
   - `starrocks://user:pass@192.168.1.100:9030/analytics`
+
+Password precedence:
+- A password embedded in `STARROCKS_URL` wins, including an explicit empty password like `user:@host:9030/db`.
+- If `STARROCKS_URL` omits the password, `STARROCKS_PASSWORD` is used when set.
+- If neither explicit password source is set and `STARROCKS_PASSWORD_KEYCHAIN_SERVICE` is configured, the password is read from macOS Keychain.
+
+**macOS Keychain example**
+
+Store the password:
+
+```bash
+security add-generic-password -U -a root -s mcp-server-starrocks -w 'secret'
+```
+
+Verify the stored password:
+
+```bash
+security find-generic-password -a root -s mcp-server-starrocks -w
+```
+
+Use it with this server:
+
+```bash
+export STARROCKS_URL=root@localhost:9030/test_db
+export STARROCKS_PASSWORD_KEYCHAIN_SERVICE=mcp-server-starrocks
+export STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT=root
+```
 
 ### Additional Configuration
 

--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -25,6 +25,7 @@ import adbc_driver_manager
 import adbc_driver_flightsql.dbapi as flight_sql
 from adbc_driver_manager import Error as adbcError
 import pandas as pd
+from .secret_resolver import resolve_password
 
 
 @dataclass
@@ -97,7 +98,7 @@ class PerfAnalysisInput(TypedDict):
     analyze_profile: NotRequired[Optional[str]]
 
 
-def parse_connection_url(connection_url: str) -> dict:
+def _parse_connection_url_details(connection_url: str) -> tuple[dict, bool]:
     """
     Parse connection URL into dict with user, password, host, port, database.
     
@@ -122,6 +123,7 @@ def parse_connection_url(connection_url: str) -> dict:
         raise ValueError(f"Invalid connection URL: {connection_url}")
     
     result = match.groupdict()
+    password_provided = result['password'] is not None
 
     # Only keep connection parameters that mysql.connector supports
     # Filter out None values and schema (which is not a mysql.connector parameter)
@@ -142,6 +144,12 @@ def parse_connection_url(connection_url: str) -> dict:
 
     # Note: schema is intentionally excluded as it's not supported by mysql.connector
 
+    return filtered_result, password_provided
+
+
+def parse_connection_url(connection_url: str) -> dict:
+    """Parse connection URL into dict with user, password, host, port, database."""
+    filtered_result, _ = _parse_connection_url_details(connection_url)
     return filtered_result
 
 ANSI_ESCAPE_PATTERN = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
@@ -151,6 +159,19 @@ def remove_ansi_codes(text):
   return ANSI_ESCAPE_PATTERN.sub('', text)
 
 
+def _resolve_connection_password(user: str, explicit_password: str, explicit_password_provided: bool) -> str:
+    """Resolve password from explicit config first, then optional Keychain lookup."""
+    if not explicit_password_provided and 'STARROCKS_PASSWORD' in os.environ:
+        explicit_password = os.environ['STARROCKS_PASSWORD']
+        explicit_password_provided = True
+
+    return resolve_password(
+        user=user,
+        explicit_password=explicit_password,
+        explicit_password_provided=explicit_password_provided
+    )
+
+
 class DBClient:
     """Simplified database client for StarRocks connection and query execution."""
     
@@ -158,15 +179,25 @@ class DBClient:
         self.enable_dummy_test = bool(os.getenv('STARROCKS_DUMMY_TEST'))
         self.enable_arrow_flight_sql = bool(os.getenv('STARROCKS_FE_ARROW_FLIGHT_SQL_PORT'))
         if os.getenv('STARROCKS_URL'):
-            self.connection_params = parse_connection_url(os.getenv('STARROCKS_URL'))
+            self.connection_params, url_password_provided = _parse_connection_url_details(os.getenv('STARROCKS_URL'))
+            self.connection_params['password'] = _resolve_connection_password(
+                user=self.connection_params['user'],
+                explicit_password=self.connection_params['password'],
+                explicit_password_provided=url_password_provided
+            )
             # Convert port to integer for mysql.connector
             self.connection_params['port'] = int(self.connection_params['port'])
         else:
+            user = os.getenv('STARROCKS_USER', 'root')
             self.connection_params = {
                 'host': os.getenv('STARROCKS_HOST', 'localhost'),
                 'port': int(os.getenv('STARROCKS_PORT', '9030')),
-                'user': os.getenv('STARROCKS_USER', 'root'),
-                'password': os.getenv('STARROCKS_PASSWORD', ''),
+                'user': user,
+                'password': _resolve_connection_password(
+                    user=user,
+                    explicit_password=os.getenv('STARROCKS_PASSWORD', ''),
+                    explicit_password_provided='STARROCKS_PASSWORD' in os.environ
+                ),
                 'database': os.getenv('STARROCKS_DB', None),
             }
         self.connection_params.update(**{

--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -180,25 +180,28 @@ class DBClient:
         self.enable_arrow_flight_sql = bool(os.getenv('STARROCKS_FE_ARROW_FLIGHT_SQL_PORT'))
         if os.getenv('STARROCKS_URL'):
             self.connection_params, url_password_provided = _parse_connection_url_details(os.getenv('STARROCKS_URL'))
-            self.connection_params['password'] = _resolve_connection_password(
-                user=self.connection_params['user'],
-                explicit_password=self.connection_params['password'],
-                explicit_password_provided=url_password_provided
-            )
+            self._password_resolution = {
+                'user': self.connection_params['user'],
+                'explicit_password': self.connection_params['password'],
+                'explicit_password_provided': url_password_provided,
+            }
             # Convert port to integer for mysql.connector
             self.connection_params['port'] = int(self.connection_params['port'])
         else:
             user = os.getenv('STARROCKS_USER', 'root')
+            explicit_password = os.getenv('STARROCKS_PASSWORD', '')
+            explicit_password_provided = 'STARROCKS_PASSWORD' in os.environ
             self.connection_params = {
                 'host': os.getenv('STARROCKS_HOST', 'localhost'),
                 'port': int(os.getenv('STARROCKS_PORT', '9030')),
                 'user': user,
-                'password': _resolve_connection_password(
-                    user=user,
-                    explicit_password=os.getenv('STARROCKS_PASSWORD', ''),
-                    explicit_password_provided='STARROCKS_PASSWORD' in os.environ
-                ),
+                'password': explicit_password,
                 'database': os.getenv('STARROCKS_DB', None),
+            }
+            self._password_resolution = {
+                'user': user,
+                'explicit_password': explicit_password,
+                'explicit_password_provided': explicit_password_provided,
             }
         self.connection_params.update(**{
             'auth_plugin': os.getenv('STARROCKS_MYSQL_AUTH_PLUGIN', 'mysql_native_password'),
@@ -217,12 +220,18 @@ class DBClient:
         
         # ADBC connection (singleton)
         self._adbc_connection = None
+
+    def _get_connection_params(self):
+        """Return connection parameters with password resolved only when needed."""
+        params = dict(self.connection_params)
+        params['password'] = _resolve_connection_password(**self._password_resolution)
+        return params
     
     def _get_connection_pool(self):
         """Get or create a connection pool for MySQL connections."""
         if self._connection_pool is None:
             try:
-                self._connection_pool = mysql.connector.pooling.MySQLConnectionPool(**self.connection_params)
+                self._connection_pool = mysql.connector.pooling.MySQLConnectionPool(**self._get_connection_params())
             except MySQLError as conn_err:
                 raise conn_err
         
@@ -258,10 +267,11 @@ class DBClient:
     
     def _create_adbc_connection(self):
         """Create a new ADBC connection."""
-        fe_host = self.connection_params['host']
+        connection_params = self._get_connection_params()
+        fe_host = connection_params['host']
         fe_port = os.getenv('STARROCKS_FE_ARROW_FLIGHT_SQL_PORT', '')
-        user = self.connection_params['user']
-        password = self.connection_params['password']
+        user = connection_params['user']
+        password = connection_params['password']
         
         try:
             connection = flight_sql.connect(

--- a/src/mcp_server_starrocks/secret_resolver.py
+++ b/src/mcp_server_starrocks/secret_resolver.py
@@ -1,0 +1,89 @@
+# Copyright 2021-present StarRocks, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+
+class SecretResolutionError(RuntimeError):
+    """Raised when secret lookup is configured but cannot resolve a password."""
+
+
+@dataclass(frozen=True)
+class KeychainLookupConfig:
+    service: str
+    account: str
+
+
+def resolve_password(*, user: str, explicit_password: str, explicit_password_provided: bool) -> str:
+    """
+    Resolve a StarRocks password.
+
+    Explicitly configured passwords always win. When no explicit password is
+    provided and macOS Keychain lookup is configured, the password is loaded via
+    the native `security` CLI.
+    """
+    if explicit_password_provided:
+        return explicit_password
+
+    lookup = get_keychain_lookup_config(user)
+    if lookup is None:
+        return explicit_password
+
+    return read_password_from_macos_keychain(lookup)
+
+
+def get_keychain_lookup_config(user: str) -> Optional[KeychainLookupConfig]:
+    """Build Keychain lookup config from environment variables, if configured."""
+    service = os.getenv('STARROCKS_PASSWORD_KEYCHAIN_SERVICE')
+    if not service:
+        return None
+
+    account = os.getenv('STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT') or user
+    return KeychainLookupConfig(service=service, account=account)
+
+
+def read_password_from_macos_keychain(lookup: KeychainLookupConfig) -> str:
+    """Read a generic password from macOS Keychain using the `security` CLI."""
+    if sys.platform != 'darwin':
+        raise SecretResolutionError(
+            "STARROCKS_PASSWORD_KEYCHAIN_SERVICE is only supported on macOS because it relies on the `security` CLI."
+        )
+
+    security_command = shutil.which('security')
+    if security_command is None:
+        raise SecretResolutionError(
+            "macOS Keychain lookup is configured, but the `security` command is not available."
+        )
+
+    result = subprocess.run(
+        [security_command, 'find-generic-password', '-a', lookup.account, '-s', lookup.service, '-w'],
+        capture_output=True,
+        text=True,
+        check=False
+    )
+    if result.returncode != 0:
+        stderr = result.stderr.strip()
+        details = f" {stderr}" if stderr else ""
+        raise SecretResolutionError(
+            f"Unable to read StarRocks password from macOS Keychain for service '{lookup.service}' "
+            f"and account '{lookup.account}'. Create the item with `security add-generic-password` "
+            f"or set STARROCKS_PASSWORD/STARROCKS_URL instead.{details}"
+        )
+
+    return result.stdout.removesuffix('\n')

--- a/src/mcp_server_starrocks/secret_resolver.py
+++ b/src/mcp_server_starrocks/secret_resolver.py
@@ -66,6 +66,8 @@ def read_password_from_macos_keychain(lookup: KeychainLookupConfig) -> str:
         )
 
     security_command = shutil.which('security')
+    if security_command is None and os.path.exists('/usr/bin/security'):
+        security_command = '/usr/bin/security'
     if security_command is None:
         raise SecretResolutionError(
             "macOS Keychain lookup is configured, but the `security` command is not available."

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -27,6 +27,7 @@ from src.mcp_server_starrocks.db_client import (
     reset_db_connections,
     parse_connection_url
 )
+from src.mcp_server_starrocks.secret_resolver import SecretResolutionError
 
 
 class TestDBClient:
@@ -936,6 +937,113 @@ class TestParseConnectionUrl:
         assert result['host'] == 'sub.domain.com'
         assert result['port'] == '12345'
         assert result['database'] == 'my_db-name'
+
+
+class TestPasswordResolution:
+    """Test password resolution precedence and Keychain integration."""
+
+    def test_explicit_env_password_overrides_keychain_when_url_omits_password(self):
+        """Test STARROCKS_PASSWORD takes precedence when URL omits the password."""
+        with patch.dict(os.environ, {
+            'STARROCKS_URL': 'url_user@db.example.com:9030/production',
+            'STARROCKS_PASSWORD': 'env-secret',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run') as mock_run:
+                client = DBClient()
+
+        assert client.connection_params['user'] == 'url_user'
+        assert client.connection_params['password'] == 'env-secret'
+        assert client.connection_params['database'] == 'production'
+        mock_run.assert_not_called()
+
+    def test_keychain_password_defaults_account_to_user(self):
+        """Test Keychain lookup defaults the account name to the resolved StarRocks user."""
+        mock_result = MagicMock(returncode=0, stdout='keychain-secret\n', stderr='')
+
+        with patch.dict(os.environ, {
+            'STARROCKS_USER': 'analytics_user',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
+                with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
+                    with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result) as mock_run:
+                        client = DBClient()
+
+        assert client.connection_params['user'] == 'analytics_user'
+        assert client.connection_params['password'] == 'keychain-secret'
+        mock_run.assert_called_once_with(
+            ['/usr/bin/security', 'find-generic-password', '-a', 'analytics_user', '-s', 'mcp-server-starrocks', '-w'],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+
+    def test_keychain_password_used_for_url_without_password(self):
+        """Test URL config can omit the password and fall back to Keychain."""
+        mock_result = MagicMock(returncode=0, stdout='url-keychain-secret\n', stderr='')
+
+        with patch.dict(os.environ, {
+            'STARROCKS_URL': 'url_user@db.example.com:9030/production',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+            'STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT': 'shared-account',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
+                with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
+                    with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result) as mock_run:
+                        client = DBClient()
+
+        assert client.connection_params['user'] == 'url_user'
+        assert client.connection_params['host'] == 'db.example.com'
+        assert client.connection_params['port'] == 9030
+        assert client.connection_params['database'] == 'production'
+        assert client.connection_params['password'] == 'url-keychain-secret'
+        mock_run.assert_called_once_with(
+            ['/usr/bin/security', 'find-generic-password', '-a', 'shared-account', '-s', 'mcp-server-starrocks', '-w'],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+
+    def test_explicit_empty_url_password_disables_keychain_fallback(self):
+        """Test an explicit empty password in STARROCKS_URL bypasses Keychain lookup."""
+        with patch.dict(os.environ, {
+            'STARROCKS_URL': 'url_user:@db.example.com:9030/production',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run') as mock_run:
+                client = DBClient()
+
+        assert client.connection_params['password'] == ''
+        mock_run.assert_not_called()
+
+    def test_missing_keychain_item_raises_clear_error(self):
+        """Test missing Keychain items raise a clear startup error."""
+        mock_result = MagicMock(
+            returncode=44,
+            stdout='',
+            stderr='security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.'
+        )
+
+        with patch.dict(os.environ, {
+            'STARROCKS_USER': 'analytics_user',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
+                with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
+                    with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result):
+                        with pytest.raises(SecretResolutionError, match='mcp-server-starrocks'):
+                            DBClient()
+
+    def test_non_macos_keychain_config_fails_fast(self):
+        """Test Keychain lookup is rejected with a clear error on non-macOS systems."""
+        with patch.dict(os.environ, {
+            'STARROCKS_USER': 'analytics_user',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'linux'):
+                with pytest.raises(SecretResolutionError, match='only supported on macOS'):
+                    DBClient()
 
 
 class TestDummyMode:

--- a/tests/test_db_client.py
+++ b/tests/test_db_client.py
@@ -944,22 +944,29 @@ class TestPasswordResolution:
 
     def test_explicit_env_password_overrides_keychain_when_url_omits_password(self):
         """Test STARROCKS_PASSWORD takes precedence when URL omits the password."""
+        mock_pool = MagicMock()
         with patch.dict(os.environ, {
             'STARROCKS_URL': 'url_user@db.example.com:9030/production',
             'STARROCKS_PASSWORD': 'env-secret',
             'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
         }, clear=True):
             with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run') as mock_run:
-                client = DBClient()
+                with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool) as mock_pool_ctor:
+                    client = DBClient()
+                    mock_run.assert_not_called()
+                    client._get_connection_pool()
 
         assert client.connection_params['user'] == 'url_user'
-        assert client.connection_params['password'] == 'env-secret'
+        assert client.connection_params['password'] == ''
         assert client.connection_params['database'] == 'production'
         mock_run.assert_not_called()
+        mock_pool_ctor.assert_called_once()
+        assert mock_pool_ctor.call_args.kwargs['password'] == 'env-secret'
 
     def test_keychain_password_defaults_account_to_user(self):
         """Test Keychain lookup defaults the account name to the resolved StarRocks user."""
         mock_result = MagicMock(returncode=0, stdout='keychain-secret\n', stderr='')
+        mock_pool = MagicMock()
 
         with patch.dict(os.environ, {
             'STARROCKS_USER': 'analytics_user',
@@ -968,10 +975,39 @@ class TestPasswordResolution:
             with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
                 with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
                     with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result) as mock_run:
-                        client = DBClient()
+                        with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool):
+                            client = DBClient()
+                            assert client.connection_params['password'] == ''
+                            mock_run.assert_not_called()
+                            client._get_connection_pool()
 
         assert client.connection_params['user'] == 'analytics_user'
-        assert client.connection_params['password'] == 'keychain-secret'
+        assert client.connection_params['password'] == ''
+        mock_run.assert_called_once_with(
+            ['/usr/bin/security', 'find-generic-password', '-a', 'analytics_user', '-s', 'mcp-server-starrocks', '-w'],
+            capture_output=True,
+            text=True,
+            check=False
+        )
+
+    def test_keychain_password_uses_usr_bin_security_when_path_is_empty(self):
+        """Test macOS lookup falls back to /usr/bin/security when PATH does not expose it."""
+        mock_result = MagicMock(returncode=0, stdout='keychain-secret\n', stderr='')
+        mock_pool = MagicMock()
+
+        with patch.dict(os.environ, {
+            'STARROCKS_USER': 'analytics_user',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
+                with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value=None):
+                    with patch('src.mcp_server_starrocks.secret_resolver.os.path.exists', return_value=True):
+                        with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result) as mock_run:
+                            with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool):
+                                client = DBClient()
+                                client._get_connection_pool()
+
+        assert client.connection_params['password'] == ''
         mock_run.assert_called_once_with(
             ['/usr/bin/security', 'find-generic-password', '-a', 'analytics_user', '-s', 'mcp-server-starrocks', '-w'],
             capture_output=True,
@@ -982,6 +1018,7 @@ class TestPasswordResolution:
     def test_keychain_password_used_for_url_without_password(self):
         """Test URL config can omit the password and fall back to Keychain."""
         mock_result = MagicMock(returncode=0, stdout='url-keychain-secret\n', stderr='')
+        mock_pool = MagicMock()
 
         with patch.dict(os.environ, {
             'STARROCKS_URL': 'url_user@db.example.com:9030/production',
@@ -991,13 +1028,17 @@ class TestPasswordResolution:
             with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
                 with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
                     with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result) as mock_run:
-                        client = DBClient()
+                        with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool):
+                            client = DBClient()
+                            assert client.connection_params['password'] == ''
+                            mock_run.assert_not_called()
+                            client._get_connection_pool()
 
         assert client.connection_params['user'] == 'url_user'
         assert client.connection_params['host'] == 'db.example.com'
         assert client.connection_params['port'] == 9030
         assert client.connection_params['database'] == 'production'
-        assert client.connection_params['password'] == 'url-keychain-secret'
+        assert client.connection_params['password'] == ''
         mock_run.assert_called_once_with(
             ['/usr/bin/security', 'find-generic-password', '-a', 'shared-account', '-s', 'mcp-server-starrocks', '-w'],
             capture_output=True,
@@ -1024,6 +1065,7 @@ class TestPasswordResolution:
             stdout='',
             stderr='security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.'
         )
+        mock_pool = MagicMock()
 
         with patch.dict(os.environ, {
             'STARROCKS_USER': 'analytics_user',
@@ -1032,18 +1074,38 @@ class TestPasswordResolution:
             with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'darwin'):
                 with patch('src.mcp_server_starrocks.secret_resolver.shutil.which', return_value='/usr/bin/security'):
                     with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run', return_value=mock_result):
-                        with pytest.raises(SecretResolutionError, match='mcp-server-starrocks'):
-                            DBClient()
+                        with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool):
+                            client = DBClient()
+                            with pytest.raises(SecretResolutionError, match='mcp-server-starrocks'):
+                                client._get_connection_pool()
 
     def test_non_macos_keychain_config_fails_fast(self):
-        """Test Keychain lookup is rejected with a clear error on non-macOS systems."""
+        """Test Keychain lookup is rejected with a clear error on non-macOS systems when connecting."""
+        mock_pool = MagicMock()
+
         with patch.dict(os.environ, {
             'STARROCKS_USER': 'analytics_user',
             'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
         }, clear=True):
             with patch('src.mcp_server_starrocks.secret_resolver.sys.platform', 'linux'):
-                with pytest.raises(SecretResolutionError, match='only supported on macOS'):
-                    DBClient()
+                with patch('src.mcp_server_starrocks.db_client.mysql.connector.pooling.MySQLConnectionPool', return_value=mock_pool):
+                    client = DBClient()
+                    with pytest.raises(SecretResolutionError, match='only supported on macOS'):
+                        client._get_connection_pool()
+
+    def test_dummy_mode_does_not_resolve_keychain_password(self):
+        """Test dummy mode still works even if Keychain lookup is configured."""
+        with patch.dict(os.environ, {
+            'STARROCKS_DUMMY_TEST': '1',
+            'STARROCKS_PASSWORD_KEYCHAIN_SERVICE': 'mcp-server-starrocks',
+        }, clear=True):
+            with patch('src.mcp_server_starrocks.secret_resolver.subprocess.run') as mock_run:
+                client = DBClient()
+                result = client.execute("SELECT * FROM any_table")
+
+        assert result.success is True
+        assert result.rows == [['aaa'], ['bbb'], ['ccc']]
+        mock_run.assert_not_called()
 
 
 class TestDummyMode:


### PR DESCRIPTION
## Summary

- add optional macOS Keychain-backed password lookup via the native `security` CLI
- keep existing plaintext env var behavior unchanged unless the new Keychain env var is explicitly configured
- support `STARROCKS_URL` without an inline password while preserving explicit empty-password behavior
- document the new env vars and add focused tests for precedence and failure cases

Fixes #38.

## Details

This change adds two optional environment variables:

- `STARROCKS_PASSWORD_KEYCHAIN_SERVICE`
- `STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT`

Password precedence is:

1. password embedded in `STARROCKS_URL`
2. `STARROCKS_PASSWORD`
3. macOS Keychain lookup when `STARROCKS_PASSWORD_KEYCHAIN_SERVICE` is configured

If Keychain lookup is explicitly configured on a non-macOS system, startup now fails fast with a clear error instead of silently falling back.

## Test plan

- `uv --directory /Users/yakir.g/git/mcp-server-starrocks run --python /usr/local/bin/python3.11 --extra test pytest tests/test_db_client.py -q -k 'PasswordResolution or ParseConnectionUrl'`

Thank you,
Yakir Gibraltar
