### PR TITLE
Support TLS/SSL options for StarRocks connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,38 @@ export STARROCKS_PASSWORD_KEYCHAIN_ACCOUNT=root
 
 - `STARROCKS_MYSQL_AUTH_PLUGIN`: (Optional) Specifies the authentication plugin to use when connecting to the StarRocks FE service. For example, set to `mysql_clear_password` if your StarRocks deployment requires clear text password authentication (such as when using certain LDAP or external authentication setups). Only set this if your environment specifically requires it; otherwise, the default auth_plugin is used.
 
+### TLS / SSL Configuration
+
+These variables control TLS for the connection. When none of them are set, the underlying `mysql.connector` keeps its default behavior (`ssl-mode=PREFERRED`): the connection is encrypted if the server supports TLS, but the server certificate is **not** verified. For real security, provide a CA certificate and enable verification.
+
+- `STARROCKS_SSL_DISABLED`: (Optional) Set to `true` to force-disable TLS. Overrides all other SSL settings. Defaults to `false`.
+- `STARROCKS_SSL_CA`: (Optional) Path to the CA certificate (PEM) used to verify the StarRocks server certificate.
+- `STARROCKS_SSL_CERT`: (Optional) Path to the client certificate (PEM) for mutual TLS (mTLS).
+- `STARROCKS_SSL_KEY`: (Optional) Path to the client private key (PEM) for mutual TLS (mTLS).
+- `STARROCKS_SSL_VERIFY_CERT`: (Optional) Set to `true` to verify the server certificate against the CA. Defaults to `false`.
+- `STARROCKS_SSL_VERIFY_IDENTITY`: (Optional) Set to `true` to also verify that the server hostname matches the certificate. Defaults to `false`.
+- `STARROCKS_TLS_VERSIONS`: (Optional) Comma-separated list of allowed TLS versions, e.g. `TLSv1.2,TLSv1.3`.
+
+Example (verify the server against a CA certificate):
+
+```json
+"env": {
+  "STARROCKS_HOST": "your-fe-host",
+  "STARROCKS_PORT": "9030",
+  "STARROCKS_USER": "root",
+  "STARROCKS_PASSWORD": "your-password",
+  "STARROCKS_SSL_CA": "/path/to/ca.pem",
+  "STARROCKS_SSL_VERIFY_CERT": "true",
+  "STARROCKS_SSL_VERIFY_IDENTITY": "true"
+}
+```
+
+For the high-performance **Arrow Flight SQL** connection (enabled via `STARROCKS_FE_ARROW_FLIGHT_SQL_PORT`), TLS is controlled separately:
+
+- `STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS`: (Optional) Set to `true` to use `grpc+tls://` instead of plaintext `grpc://`. When enabled, `STARROCKS_SSL_CA` is used as the TLS root certificate and `STARROCKS_SSL_VERIFY_CERT=false` (default) skips server certificate verification.
+
+> Security note: avoid storing plaintext passwords directly in `mcp.json`. Prefer injecting `STARROCKS_PASSWORD` (and certificate paths) from a secrets manager or environment, and never commit credentials to version control.
+
 - `MCP_TRANSPORT_MODE`: (Optional) Communication mode that specifies how the MCP Server exposes its services. Available options:
   - `stdio` (default): Communicates through standard input/output, suitable for MCP Host hosting.
   - `streamable-http` (Streamable HTTP): Starts as a Streamable HTTP Server, supporting RESTful API calls.

--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -176,6 +176,94 @@ def parse_connection_url(connection_url: str) -> dict:
     filtered_result, _ = _parse_connection_url_details(connection_url)
     return filtered_result
 
+def _env_flag(name: str, default: bool = False) -> bool:
+    """Read a boolean-ish environment variable."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ('true', '1', 'yes', 'on')
+
+
+def _build_mysql_ssl_options() -> dict:
+    """
+    Build TLS/SSL connection options for mysql.connector from environment variables.
+
+    Supported environment variables:
+    - STARROCKS_SSL_DISABLED:        'true' to force-disable TLS (overrides everything else).
+    - STARROCKS_SSL_CA:              path to the CA certificate (PEM) used to verify the server.
+    - STARROCKS_SSL_CERT:            path to the client certificate (PEM) for mutual TLS.
+    - STARROCKS_SSL_KEY:             path to the client private key (PEM) for mutual TLS.
+    - STARROCKS_SSL_VERIFY_CERT:     'true' to verify the server certificate against the CA.
+    - STARROCKS_SSL_VERIFY_IDENTITY: 'true' to verify the server hostname against the certificate.
+    - STARROCKS_TLS_VERSIONS:        comma-separated list, e.g. "TLSv1.2,TLSv1.3".
+
+    Notes:
+    - When none of these are set, no SSL keys are injected and mysql.connector keeps its
+      default behavior (ssl-mode PREFERRED: encrypted if the server supports it, no verification).
+    - For real security, set STARROCKS_SSL_CA together with STARROCKS_SSL_VERIFY_CERT=true
+      (and STARROCKS_SSL_VERIFY_IDENTITY=true to also check the hostname).
+    """
+    if _env_flag('STARROCKS_SSL_DISABLED', False):
+        return {'ssl_disabled': True}
+
+    opts: dict = {}
+    ssl_ca = os.getenv('STARROCKS_SSL_CA')
+    ssl_cert = os.getenv('STARROCKS_SSL_CERT')
+    ssl_key = os.getenv('STARROCKS_SSL_KEY')
+    if ssl_ca:
+        opts['ssl_ca'] = ssl_ca
+    if ssl_cert:
+        opts['ssl_cert'] = ssl_cert
+    if ssl_key:
+        opts['ssl_key'] = ssl_key
+    if _env_flag('STARROCKS_SSL_VERIFY_CERT', False):
+        opts['ssl_verify_cert'] = True
+    if _env_flag('STARROCKS_SSL_VERIFY_IDENTITY', False):
+        opts['ssl_verify_identity'] = True
+
+    tls_versions = os.getenv('STARROCKS_TLS_VERSIONS')
+    if tls_versions:
+        versions = [v.strip() for v in tls_versions.split(',') if v.strip()]
+        if versions:
+            opts['tls_versions'] = versions
+
+    return opts
+
+
+def _build_flight_sql_tls(fe_host: str, fe_port: str) -> tuple:
+    """
+    Build the Arrow Flight SQL URI and TLS db_kwargs from environment variables.
+
+    Supported environment variables:
+    - STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS: 'true' to use grpc+tls:// instead of plaintext grpc://.
+    - STARROCKS_SSL_CA:                      path to the CA certificate (PEM) used as TLS root certs.
+    - STARROCKS_SSL_VERIFY_CERT:             when 'false' (default), skip server certificate verification.
+
+    Returns a tuple of (uri, tls_db_kwargs).
+    """
+    use_tls = _env_flag('STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS', False)
+    if not use_tls:
+        return f"grpc://{fe_host}:{fe_port}", {}
+
+    # Option keys defined by the ADBC Flight SQL driver.
+    tls_skip_verify_key = "adbc.flight.sql.client_option.tls_skip_verify"
+    tls_root_certs_key = "adbc.flight.sql.client_option.tls_root_certs"
+
+    tls_db_kwargs: dict = {}
+    verify_cert = _env_flag('STARROCKS_SSL_VERIFY_CERT', False)
+    tls_db_kwargs[tls_skip_verify_key] = "false" if verify_cert else "true"
+
+    ssl_ca = os.getenv('STARROCKS_SSL_CA')
+    if ssl_ca:
+        try:
+            with open(ssl_ca, 'r') as f:
+                tls_db_kwargs[tls_root_certs_key] = f.read()
+        except OSError as e:
+            print(f"Warning: could not read STARROCKS_SSL_CA '{ssl_ca}': {e}")
+
+    return f"grpc+tls://{fe_host}:{fe_port}", tls_db_kwargs
+
+
 ANSI_ESCAPE_PATTERN = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
 
@@ -237,6 +325,8 @@ class DBClient:
             'connect_timeout': int(os.getenv('STARROCKS_CONNECTION_TIMEOUT', '10')),
             'use_pure': os.getenv('STARROCKS_USE_PURE', 'false').lower() in ('true', '1', 'yes'),
         })
+        # Apply optional TLS/SSL options for the MySQL protocol connection.
+        self.connection_params.update(_build_mysql_ssl_options())
         self.default_database = self.connection_params.get('database')
 
         # MySQL connection pool
@@ -326,13 +416,17 @@ class DBClient:
         user = connection_params['user']
         password = connection_params['password']
         
+        uri, tls_db_kwargs = _build_flight_sql_tls(fe_host, fe_port)
+        db_kwargs = {
+            adbc_driver_manager.DatabaseOptions.USERNAME.value: user,
+            adbc_driver_manager.DatabaseOptions.PASSWORD.value: password,
+        }
+        db_kwargs.update(tls_db_kwargs)
+
         try:
             connection = flight_sql.connect(
-                uri=f"grpc://{fe_host}:{fe_port}",
-                db_kwargs={
-                    adbc_driver_manager.DatabaseOptions.USERNAME.value: user,
-                    adbc_driver_manager.DatabaseOptions.PASSWORD.value: password,
-                }
+                uri=uri,
+                db_kwargs=db_kwargs,
             )
             
             # Switch to default database if set

--- a/tests/test_ssl_options.py
+++ b/tests/test_ssl_options.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for TLS/SSL option builders in db_client.
+
+These tests are pure-function tests and do NOT require a running StarRocks
+cluster. They lock in the env-var -> mysql.connector / Arrow Flight SQL TLS
+mapping (including the VERIFY_CA usage validated against bts JFK ISR).
+
+Run with: pytest tests/test_ssl_options.py -v
+"""
+
+import os
+import contextlib
+import pytest
+
+from src.mcp_server_starrocks.db_client import (
+    _build_mysql_ssl_options,
+    _build_flight_sql_tls,
+    _env_flag,
+)
+
+# ADBC Flight SQL option keys (must match db_client implementation).
+TLS_SKIP_VERIFY = "adbc.flight.sql.client_option.tls_skip_verify"
+TLS_ROOT_CERTS = "adbc.flight.sql.client_option.tls_root_certs"
+
+# All env vars consumed by the SSL/TLS builders.
+SSL_ENV_KEYS = [
+    "STARROCKS_SSL_DISABLED",
+    "STARROCKS_SSL_CA",
+    "STARROCKS_SSL_CERT",
+    "STARROCKS_SSL_KEY",
+    "STARROCKS_SSL_VERIFY_CERT",
+    "STARROCKS_SSL_VERIFY_IDENTITY",
+    "STARROCKS_TLS_VERSIONS",
+    "STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS",
+]
+
+
+@contextlib.contextmanager
+def ssl_env(**overrides):
+    """Clear all SSL env vars, apply only the given overrides, then restore."""
+    saved = {k: os.environ.pop(k, None) for k in SSL_ENV_KEYS}
+    try:
+        for key, value in overrides.items():
+            os.environ[key] = value
+        yield
+    finally:
+        for key in SSL_ENV_KEYS:
+            os.environ.pop(key, None)
+        for key, value in saved.items():
+            if value is not None:
+                os.environ[key] = value
+
+
+class TestEnvFlag:
+    """Test cases for the _env_flag helper."""
+
+    def test_unset_returns_default(self):
+        with ssl_env():
+            assert _env_flag("STARROCKS_SSL_VERIFY_CERT") is False
+            assert _env_flag("STARROCKS_SSL_VERIFY_CERT", default=True) is True
+
+    @pytest.mark.parametrize("value", ["true", "True", "1", "yes", "on", "  TRUE  "])
+    def test_truthy_values(self, value):
+        with ssl_env(STARROCKS_SSL_VERIFY_CERT=value):
+            assert _env_flag("STARROCKS_SSL_VERIFY_CERT") is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "", "random"])
+    def test_falsy_values(self, value):
+        with ssl_env(STARROCKS_SSL_VERIFY_CERT=value):
+            assert _env_flag("STARROCKS_SSL_VERIFY_CERT") is False
+
+
+class TestBuildMysqlSslOptions:
+    """Test cases for _build_mysql_ssl_options."""
+
+    def test_no_env_returns_empty(self):
+        """No SSL env vars -> empty dict (mysql.connector keeps its defaults)."""
+        with ssl_env():
+            assert _build_mysql_ssl_options() == {}
+
+    def test_verify_ca_only(self):
+        """The bts JFK ISR case: VERIFY_CA, no certs, no identity check."""
+        with ssl_env(STARROCKS_SSL_VERIFY_CERT="true"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {"ssl_verify_cert": True}
+        # VERIFY_CA must NOT enable hostname verification.
+        assert "ssl_verify_identity" not in opts
+        # And must NOT require any certificate file.
+        assert "ssl_ca" not in opts
+
+    def test_verify_identity(self):
+        with ssl_env(STARROCKS_SSL_VERIFY_CERT="true",
+                     STARROCKS_SSL_VERIFY_IDENTITY="true"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {"ssl_verify_cert": True, "ssl_verify_identity": True}
+
+    def test_ca_path(self):
+        with ssl_env(STARROCKS_SSL_CA="/tmp/ca.pem",
+                     STARROCKS_SSL_VERIFY_CERT="true"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {"ssl_ca": "/tmp/ca.pem", "ssl_verify_cert": True}
+
+    def test_mutual_tls(self):
+        with ssl_env(STARROCKS_SSL_CA="/tmp/ca.pem",
+                     STARROCKS_SSL_CERT="/tmp/client.pem",
+                     STARROCKS_SSL_KEY="/tmp/client.key",
+                     STARROCKS_SSL_VERIFY_CERT="true"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {
+            "ssl_ca": "/tmp/ca.pem",
+            "ssl_cert": "/tmp/client.pem",
+            "ssl_key": "/tmp/client.key",
+            "ssl_verify_cert": True,
+        }
+
+    def test_tls_versions_parsed_into_list(self):
+        with ssl_env(STARROCKS_TLS_VERSIONS="TLSv1.2, TLSv1.3 ,"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {"tls_versions": ["TLSv1.2", "TLSv1.3"]}
+
+    def test_ssl_disabled_overrides_everything(self):
+        with ssl_env(STARROCKS_SSL_DISABLED="true",
+                     STARROCKS_SSL_CA="/tmp/ca.pem",
+                     STARROCKS_SSL_VERIFY_CERT="true"):
+            opts = _build_mysql_ssl_options()
+        assert opts == {"ssl_disabled": True}
+
+
+class TestBuildFlightSqlTls:
+    """Test cases for _build_flight_sql_tls."""
+
+    def test_plaintext_by_default(self):
+        with ssl_env():
+            uri, kwargs = _build_flight_sql_tls("fe-host", "9408")
+        assert uri == "grpc://fe-host:9408"
+        assert kwargs == {}
+
+    def test_tls_skip_verify_when_not_verifying(self):
+        with ssl_env(STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS="true"):
+            uri, kwargs = _build_flight_sql_tls("fe-host", "9408")
+        assert uri == "grpc+tls://fe-host:9408"
+        assert kwargs[TLS_SKIP_VERIFY] == "true"
+        assert TLS_ROOT_CERTS not in kwargs
+
+    def test_tls_verify_cert(self):
+        with ssl_env(STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS="true",
+                     STARROCKS_SSL_VERIFY_CERT="true"):
+            uri, kwargs = _build_flight_sql_tls("fe-host", "9408")
+        assert uri == "grpc+tls://fe-host:9408"
+        assert kwargs[TLS_SKIP_VERIFY] == "false"
+
+    def test_tls_root_certs_read_from_ca_file(self, tmp_path):
+        ca_file = tmp_path / "ca.pem"
+        ca_file.write_text("-----BEGIN CERTIFICATE-----\nFAKE\n-----END CERTIFICATE-----\n")
+        with ssl_env(STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS="true",
+                     STARROCKS_SSL_VERIFY_CERT="true",
+                     STARROCKS_SSL_CA=str(ca_file)):
+            uri, kwargs = _build_flight_sql_tls("fe-host", "9408")
+        assert uri == "grpc+tls://fe-host:9408"
+        assert kwargs[TLS_SKIP_VERIFY] == "false"
+        assert "BEGIN CERTIFICATE" in kwargs[TLS_ROOT_CERTS]
+
+    def test_missing_ca_file_is_tolerated(self):
+        """A non-existent CA path should not raise; root certs key is just omitted."""
+        with ssl_env(STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS="true",
+                     STARROCKS_SSL_CA="/nonexistent/ca.pem"):
+            uri, kwargs = _build_flight_sql_tls("fe-host", "9408")
+        assert uri == "grpc+tls://fe-host:9408"
+        assert TLS_ROOT_CERTS not in kwargs
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Add environment-variable driven TLS/SSL support so the MCP server can connect to TLS-enabled StarRocks clusters. This includes support for `VERIFY_CA` **without** requiring an explicitly specified certificate (verified against the system trust store), which is the common setup for managed/internal clusters.

## Motivation

Previously `db_client.py` passed no SSL parameters to `mysql.connector`, and the Arrow Flight SQL path was hard-coded to plaintext `grpc://`. Against a TLS-enabled cluster this either failed (e.g. `SSL connection error: SSL_CTX_set_default_verify_paths failed` with the C extension) or silently fell back to an unverified connection, with no way to require/verify TLS.

## Changes

- **MySQL protocol**: new `_build_mysql_ssl_options()` maps env vars to `mysql.connector` `ssl_*` params and injects them into the connection pool config.
- **Arrow Flight SQL**: new `_build_flight_sql_tls()` switches the URI to `grpc+tls://` and wires TLS root certs / skip-verify into `db_kwargs`.
- **Docs**: document all new variables (and a security note about plaintext passwords) in `README.md`.
- **Tests**: add pure-function unit tests in `tests/test_ssl_options.py` (no running cluster required).

## New environment variables

| Variable | Purpose |
| --- | --- |
| `STARROCKS_SSL_DISABLED` | Force-disable TLS (overrides everything else) |
| `STARROCKS_SSL_CA` | CA certificate path used to verify the server |
| `STARROCKS_SSL_CERT` / `STARROCKS_SSL_KEY` | Client cert/key for mutual TLS |
| `STARROCKS_SSL_VERIFY_CERT` | Verify the server certificate (VERIFY_CA) |
| `STARROCKS_SSL_VERIFY_IDENTITY` | Also verify the server hostname (VERIFY_IDENTITY) |
| `STARROCKS_TLS_VERSIONS` | Allowed TLS versions, e.g. `TLSv1.2,TLSv1.3` |
| `STARROCKS_FE_ARROW_FLIGHT_SQL_USE_TLS` | Use `grpc+tls://` for the Flight SQL connection |

When none are set, behavior is unchanged (mysql.connector default, backward compatible).

## Example (VERIFY_CA, no certificate files)

    "env": {
      "STARROCKS_HOST": "your-fe-host",
      "STARROCKS_PORT": "9030",
      "STARROCKS_USER": "root",
      "STARROCKS_PASSWORD": "******",
      "STARROCKS_USE_PURE": "true",
      "STARROCKS_SSL_VERIFY_CERT": "true"
    }

## Testing

- `pytest tests/test_ssl_options.py -v` → 25 passed.
- Manually verified an end-to-end TLS (VERIFY_CA) connection against an internal StarRocks cluster using the config above.

## Notes

- `STARROCKS_USE_PURE=true` is recommended for VERIFY_CA: the pure-Python connector uses `ssl.create_default_context()` + `load_default_certs()` (system trust store), avoiding the C extension's `SSL_CTX_set_default_verify_paths` failure on some platforms.
- No breaking changes; SSL options are only applied when the corresponding env vars are set.


Hi @decster please help to review this pr.
