### PR TITLE
Add top bad tables health analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,19 @@ For the high-performance **Arrow Flight SQL** connection (enabled via `STARROCKS
     ```
   - **Output:** Text summary plus structured content containing ranked rows with `db`, `table`, and `visit_count`.
 
+- `top_bad_tables`
+
+  - **Description:** Get top bad tables by table health score, following Star Management Studio's `top-bad-tables` logic. It reuses the table-health calculation based on `information_schema.be_tablets` and `information_schema.partitions_meta`, filters out system schemas, orders by `table_health_score` ascending, and returns the lowest-scoring tables.
+  - **Input:**
+    ```json
+    {
+      "db": "optional database/schema filter",
+      "table": "optional table name substring filter",
+      "top_n": 20
+    }
+    ```
+  - **Output:** Text summary plus structured content containing ranked rows with table health fields such as `db`, `table`, `tablet_num`, `replica_score`, `tablet_score`, and `table_health_score`.
+
 - `query_and_plotly_chart`
 
   - **Description:** Executes a SQL query, loads the results into a Pandas DataFrame, and generates a Plotly chart using a provided Python expression. Designed for visualization in supporting UIs.

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -36,7 +36,7 @@ import plotly.graph_objs
 from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware import Middleware
-from .db_client import get_db_client, reset_db_connections, ResultSet, PerfAnalysisInput, remove_ansi_codes
+from .db_client import get_db_client, reset_db_connections, ResultSet, PerfAnalysisInput
 from .db_summary_manager import get_db_summary_manager
 from .table_management_tools import (
     TableManagementTools,

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -36,10 +36,11 @@ import plotly.graph_objs
 from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware import Middleware
-from .db_client import get_db_client, reset_db_connections, ResultSet, PerfAnalysisInput
+from .db_client import get_db_client, reset_db_connections, ResultSet, PerfAnalysisInput, remove_ansi_codes
 from .db_summary_manager import get_db_summary_manager
 from .table_management_tools import (
     TableManagementTools,
+    format_top_bad_tables_analysis,
     format_top_hot_tables_analysis,
 )
 from .connection_health_checker import (
@@ -72,7 +73,6 @@ _transport_mode = os.getenv('MCP_TRANSPORT_MODE', 'stdio')
 _EXT_TO_FORMAT = {'.csv': 'csv', '.tsv': 'tsv', '.json': 'json',
                   '.jsonl': 'jsonl', '.ndjson': 'jsonl'}
 _SUPPORTED_OUTPUT_FORMATS = ('csv', 'tsv', 'json', 'jsonl')
-
 
 def _resolve_output_path(output_file: str) -> str:
     """Resolve output_file to an absolute path.
@@ -443,6 +443,26 @@ def top_hot_tables(
     )
     return ToolResult(
         content=[TextContent(type='text', text=format_top_hot_tables_analysis(result))],
+        structured_content=result,
+    )
+
+@mcp.tool(description="Get top bad tables by table health score")
+def top_bad_tables(
+        db: Annotated[str|None, Field(
+            description="Optional database/schema filter. Matches table health db_name exactly.")] = None,
+        table: Annotated[str|None, Field(
+            description="Optional table name substring filter. Matches table_name with LIKE.")] = None,
+        top_n: Annotated[int, Field(
+            description="Number of bad tables to return. Defaults to 20 and is capped at 100.")] = 20,
+        ctx: Context = None,
+) -> ToolResult:
+    result = table_management_tools.get_top_bad_tables(
+        db=db,
+        table=table,
+        top_n=top_n,
+    )
+    return ToolResult(
+        content=[TextContent(type='text', text=format_top_bad_tables_analysis(result))],
         structured_content=result,
     )
 

--- a/src/mcp_server_starrocks/table_management_tools.py
+++ b/src/mcp_server_starrocks/table_management_tools.py
@@ -220,7 +220,7 @@ class TableManagementTools:
         if table:
             conditions.append(f"table_name LIKE {_sql_literal('%' + table + '%')}")
 
-        where_sql = "\n            AND ".join(conditions)
+        where_sql = "\n AND ".join(conditions)
         return f"""
             SELECT *
             FROM (

--- a/src/mcp_server_starrocks/table_management_tools.py
+++ b/src/mcp_server_starrocks/table_management_tools.py
@@ -108,6 +108,63 @@ class TableManagementTools:
             "top_hot_tables": top_tables,
         }
 
+    def get_top_bad_tables(
+        self,
+        db: Optional[str] = None,
+        table: Optional[str] = None,
+        top_n: int = 20,
+    ) -> dict[str, Any]:
+        """Get top bad tables."""
+        limit = _bounded_limit(top_n)
+        now = datetime.now()
+        sql = self._build_top_bad_tables_sql(db=db, table=table, top_n=limit)
+        result = self.db_client.execute(sql)
+        if not result.success:
+            return {
+                "success": False,
+                "error": result.error_message or "Failed to get top bad tables.",
+                "analysis_timestamp": now.isoformat(),
+                "top_bad_tables": [],
+            }
+
+        column_names = result.column_names or []
+        rows = result.rows or []
+        top_tables = []
+        for index, row in enumerate(rows[:limit]):
+            item = dict(zip(column_names, row))
+            top_tables.append(
+                {
+                    "rank": index + 1,
+                    "table_id": _display_number(item.get("table_id")),
+                    "db": item.get("db_name"),
+                    "table": item.get("table_name"),
+                    "partition_num": _display_number(item.get("partition_num")),
+                    "bucket_num": _display_number(item.get("bucket_num")),
+                    "replication_num": _display_number(item.get("replication_num")),
+                    "tablet_num": _display_number(item.get("tablet_num")),
+                    "replica_score": _display_number(item.get("replica_score")),
+                    "segment_score": _display_number(item.get("segment_score")),
+                    "version_score": _display_number(item.get("version_score")),
+                    "tablet_score": _display_number(item.get("tablet_score")),
+                    "table_health_score": _display_number(item.get("table_health_score")),
+                }
+            )
+
+        return {
+            "success": True,
+            "analysis_timestamp": now.isoformat(),
+            "filters": {
+                "db": db,
+                "table": table,
+                "top_n": limit,
+            },
+            "summary": {
+                "top_n_requested": limit,
+                "top_n_returned": len(top_tables),
+                "execution_time": result.execution_time,
+            },
+            "top_bad_tables": top_tables,
+        }
 
     @staticmethod
     def _build_top_hot_tables_sql(
@@ -148,6 +205,132 @@ class TableManagementTools:
             LIMIT {top_n}
             """
 
+    @staticmethod
+    def _build_top_bad_tables_sql(
+        db: Optional[str],
+        table: Optional[str],
+        top_n: int,
+    ) -> str:
+        conditions = [
+            "db_name NOT IN ('information_schema', '_statistics_', 'sys')",
+            "table_health_score IS NOT NULL",
+        ]
+        if db:
+            conditions.append(f"db_name = {_sql_literal(db)}")
+        if table:
+            conditions.append(f"table_name LIKE {_sql_literal('%' + table + '%')}")
+
+        where_sql = "\n            AND ".join(conditions)
+        return f"""
+            SELECT *
+            FROM (
+                {TableManagementTools._build_table_health_base_sql()}
+            ) table_health
+            WHERE {where_sql}
+            ORDER BY table_health_score ASC
+            LIMIT {top_n}
+            OFFSET 0
+            """
+
+    @staticmethod
+    def _build_table_health_base_sql() -> str:
+        return """
+            WITH tablet_base AS (
+                SELECT
+                    table_id,
+                    partition_id,
+                    tablet_id,
+                    MAX(num_segment) AS segment_num,
+                    MAX(num_version) AS version_num,
+                    MAX(data_size) AS tablet_size
+                FROM information_schema.be_tablets
+                GROUP BY table_id, partition_id, tablet_id
+            ),
+            tablet_stat AS (
+                SELECT
+                    table_id,
+                    AVG(segment_num) AS avg_segment,
+                    MAX(segment_num) AS max_segment,
+                    AVG(version_num) AS avg_version,
+                    MAX(version_num) AS max_version,
+                    AVG(tablet_size) AS avg_size,
+                    MAX(tablet_size) AS max_size,
+                    STDDEV_POP(tablet_size) AS size_std
+                FROM tablet_base
+                GROUP BY table_id
+            ),
+            replica_stat AS (
+                SELECT
+                    table_id,
+                    SUM(expected_replica) AS expected_replica,
+                    SUM(actual_replica) AS actual_replica
+                FROM (
+                    SELECT
+                        MAX(bt.table_id) AS table_id,
+                        pm.partition_id,
+                        pm.buckets * pm.replication_num AS expected_replica,
+                        COUNT(bt.tablet_id) AS actual_replica
+                    FROM information_schema.partitions_meta pm
+                    LEFT JOIN information_schema.be_tablets bt
+                        ON pm.partition_id = bt.partition_id
+                    WHERE pm.storage_path NOT LIKE 's3://%'
+                    GROUP BY pm.partition_id, pm.buckets, pm.replication_num
+                ) t
+                GROUP BY table_id
+            ),
+            table_meta AS (
+                SELECT
+                    db_name AS db_name,
+                    table_name AS table_name,
+                    bt.table_id AS table_id,
+                    COUNT(DISTINCT pm.partition_id) AS partition_num,
+                    MAX(buckets) AS bucket_num,
+                    MAX(replication_num) AS replication_num,
+                    COUNT(tablet_id) AS tablet_num
+                FROM information_schema.partitions_meta pm
+                LEFT JOIN information_schema.be_tablets bt
+                    ON pm.partition_id = bt.partition_id
+                WHERE db_name NOT IN ('information_schema','_statistics_','sys')
+                GROUP BY db_name, table_name, bt.table_id
+            )
+            SELECT
+                tm.db_name,
+                tm.table_name,
+                ts.table_id,
+                tm.partition_num,
+                tm.bucket_num,
+                tm.replication_num,
+                tm.tablet_num,
+                avg_segment,
+                max_segment,
+                avg_version,
+                max_version,
+                avg_size / (1024 * 1024 * 1024) AS avg_bucket_gb,
+                max_size / (1024 * 1024 * 1024) AS max_bucket_gb,
+                COALESCE(ROUND(rs.actual_replica / NULLIF(rs.expected_replica, 0) * 100, 2), 100) AS replica_score,
+                GREATEST(0, 100 - FLOOR(avg_segment / 2000) * 5) AS segment_score,
+                GREATEST(0, 100 - FLOOR((max_version - avg_version) / 10) * 5) AS version_score,
+                (
+                    GREATEST(0, 30 - FLOOR(tm.bucket_num / 1000) * 3)
+                    + GREATEST(0, 30 - FLOOR((avg_size / (1024 * 1024 * 1024)) / 2))
+                    + GREATEST(0, 40 - (size_std / avg_size) * 40)
+                ) AS tablet_score,
+                (
+                    0.35 * COALESCE((rs.actual_replica / NULLIF(rs.expected_replica, 0) * 100), 100)
+                    + 0.35 * (
+                        GREATEST(0, 30 - FLOOR(tm.bucket_num / 1000) * 3)
+                        + GREATEST(0, 30 - FLOOR((avg_size / (1024 * 1024 * 1024)) / 2))
+                        + GREATEST(0, 40 - (size_std / avg_size) * 40)
+                    )
+                    + 0.10 * GREATEST(0, 100 - FLOOR(avg_segment / 2000) * 5)
+                    + 0.20 * GREATEST(0, 100 - FLOOR((max_version - avg_version) / 10) * 5)
+                ) AS table_health_score
+            FROM tablet_stat ts
+            LEFT JOIN replica_stat rs ON ts.table_id = rs.table_id
+            LEFT JOIN table_meta tm ON ts.table_id = tm.table_id
+            WHERE table_name IS NOT NULL
+            """
+
 
 def format_top_hot_tables_analysis(result: dict[str, Any]) -> str:
     """Format top hot table information."""
@@ -173,6 +356,37 @@ def format_top_hot_tables_analysis(result: dict[str, Any]) -> str:
         lines.append(
             f"#{table.get('rank')} {table.get('db')}.{table.get('table')} "
             f"visits={table.get('visit_count')}"
+        )
+
+    return "\n".join(lines)
+
+
+def format_top_bad_tables_analysis(result: dict[str, Any]) -> str:
+    """Create a compact text summary for table health analysis."""
+    if not result.get("success"):
+        return f"Error getting top bad tables: {result.get('error', 'unknown error')}"
+
+    summary = result.get("summary", {})
+    lines = [
+        "Top bad tables analysis completed.",
+        (
+            f"Returned {summary.get('top_n_returned', 0)} "
+            f"of {summary.get('top_n_requested', 0)} requested table(s)."
+        ),
+    ]
+
+    top_tables = result.get("top_bad_tables", [])
+    if not top_tables:
+        lines.append("No bad tables found for the specified criteria.")
+        return "\n".join(lines)
+
+    lines.append("Top tables:")
+    for table in top_tables[:10]:
+        lines.append(
+            f"#{table.get('rank')} {table.get('db')}.{table.get('table')} "
+            f"health_score={table.get('table_health_score')} "
+            f"tablet_score={table.get('tablet_score')} "
+            f"replica_score={table.get('replica_score')}"
         )
 
     return "\n".join(lines)


### PR DESCRIPTION
Summary

- Add a top_bad_tables MCP tool to rank StarRocks tables by health score.

- Compute table health using four dimensions:

   - Replica health: compares actual replica count with expected replica count.
   - Tablet health: considers bucket count, average tablet size, and tablet size skew.
   - Segment health: penalizes tables with high average segment counts.
   - Version health: penalizes tables where the max tablet version count diverges significantly from the average.
