### PR TITLE
Validate identifiers and proc paths before interpolating into SQL

### DIFF
--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -34,6 +34,33 @@ from .secret_resolver import resolve_password
 # Integers beyond this range lose precision in JSON when parsed by JavaScript clients.
 MAX_SAFE_INTEGER = 2**53 - 1
 
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_PROC_PATH_RE = re.compile(r"^[A-Za-z0-9_/-]*$")
+_QUERY_UUID_RE = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def validate_sql_identifier(value: str, kind: str) -> str:
+    """Reject anything but a plain identifier before it is interpolated unquoted into SQL."""
+    if not value or not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid {kind} name: {value!r}")
+    return value
+
+
+def validate_proc_path(value: str) -> str:
+    """Reject anything but path-shaped characters before interpolating into show proc '...'."""
+    if not _PROC_PATH_RE.match(value):
+        raise ValueError(f"Invalid proc path: {value!r}")
+    return value
+
+
+def validate_query_uuid(value: str) -> str:
+    """Reject anything not matching the documented 8-4-4-4-12 hex query id format."""
+    if not _QUERY_UUID_RE.match(value):
+        raise ValueError(f"Invalid query UUID: {value!r}")
+    return value
+
 
 def _safe_json_value(v):
     """Convert integers outside JavaScript's safe integer range to strings.

--- a/src/mcp_server_starrocks/db_summary_manager.py
+++ b/src/mcp_server_starrocks/db_summary_manager.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 from loguru import logger
 
+from .db_client import validate_sql_identifier
+
 
 @dataclass
 class ColumnInfo:
@@ -243,7 +245,11 @@ class DatabaseSummaryManager:
         """Generate comprehensive database summary with intelligent prioritization"""
         if not database:
             return "Error: Database name is required"
-        
+        try:
+            validate_sql_identifier(database, "database")
+        except ValueError as e:
+            return f"Error: {e}"
+
         logger.info(f"Generating database summary for {database}, limit={limit}, refresh={refresh}")
         
         # Sync table list

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -35,7 +35,15 @@ import plotly.graph_objs
 from loguru import logger
 from starlette.middleware.cors import CORSMiddleware
 from starlette.middleware import Middleware
-from .db_client import get_db_client, reset_db_connections, ResultSet, PerfAnalysisInput
+from .db_client import (
+    get_db_client,
+    reset_db_connections,
+    ResultSet,
+    PerfAnalysisInput,
+    validate_sql_identifier,
+    validate_proc_path,
+    validate_query_uuid,
+)
 from .db_summary_manager import get_db_summary_manager
 from .table_management_tools import (
     TableManagementTools,
@@ -224,6 +232,8 @@ def get_all_databases() -> str:
 @mcp.resource(uri="starrocks:///{db}/{table}/schema", name="Table Schema",
               description="Get the schema of a table using SHOW CREATE TABLE", mime_type="text/plain")
 def get_table_schema(db: str, table: str) -> str:
+    validate_sql_identifier(db, "database")
+    validate_sql_identifier(table, "table")
     logger.debug(f"Fetching schema for table {db}.{table}")
     return db_client.execute(f"SHOW CREATE TABLE {db}.{table}").to_string()
 
@@ -231,6 +241,7 @@ def get_table_schema(db: str, table: str) -> str:
 @mcp.resource(uri="starrocks:///{db}/tables", name="Database Tables",
               description="List all tables in a specific database", mime_type="text/plain")
 def get_database_tables(db: str) -> str:
+    validate_sql_identifier(db, "database")
     logger.debug(f"Fetching tables from database {db}")
     result = db_client.execute(f"SHOW TABLES FROM {db}")
     logger.debug(f"Found {len(result.rows) if result.success and result.rows else 0} tables in {db}")
@@ -240,6 +251,7 @@ def get_database_tables(db: str) -> str:
 @mcp.resource(uri="proc:///{path*}", name="System internal information", description=SR_PROC_DESC,
               mime_type="text/plain")
 def get_system_internal_information(path: str) -> str:
+    validate_proc_path(path)
     logger.debug(f"Fetching system information for proc path: {path}")
     return db_client.execute(f"show proc '{path}'").to_string(limit=overview_length_limit)
 
@@ -390,7 +402,10 @@ def analyze_query(
         ctx: Context = None,
 ) -> str:
     sid = _safe_session_id(ctx)
+    if db:
+        validate_sql_identifier(db, "database")
     if uuid:
+        validate_query_uuid(uuid)
         logger.info(f"Analyzing query profile for UUID: {uuid}")
         return db_client.execute(f"ANALYZE PROFILE FROM '{uuid}'", db=db, session_id=sid).to_string()
     elif sql:

--- a/tests/test_sql_identifier_validation.py
+++ b/tests/test_sql_identifier_validation.py
@@ -1,0 +1,157 @@
+"""
+Unit tests for the identifier/path/UUID validators in db_client, and for the
+server.py / db_summary_manager call sites that must reject a malicious value
+before it reaches SQL text (issue #33).
+
+These tests are pure-function / mocked-db_client tests and do NOT require a
+running StarRocks cluster.
+
+Run with: pytest tests/test_sql_identifier_validation.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.mcp_server_starrocks.db_client import (
+    validate_sql_identifier,
+    validate_proc_path,
+    validate_query_uuid,
+)
+from src.mcp_server_starrocks import server
+from src.mcp_server_starrocks.db_summary_manager import DatabaseSummaryManager
+
+
+class TestValidateSqlIdentifier:
+    @pytest.mark.parametrize("value", ["db1", "_db", "My_Table", "a" * 5])
+    def test_accepts_plain_identifiers(self, value):
+        assert validate_sql_identifier(value, "database") == value
+
+    @pytest.mark.parametrize("value", [
+        "db; DROP TABLE secrets;",
+        "db`; DROP TABLE secrets;#",
+        "db.other",
+        "db name",
+        "",
+        None,
+    ])
+    def test_rejects_anything_else(self, value):
+        with pytest.raises(ValueError):
+            validate_sql_identifier(value, "database")
+
+
+class TestValidateProcPath:
+    @pytest.mark.parametrize("value", ["/backends", "/dbs/10001/10002/partitions", ""])
+    def test_accepts_path_shaped_values(self, value):
+        assert validate_proc_path(value) == value
+
+    @pytest.mark.parametrize("value", [
+        "x' UNION SELECT password FROM mysql.user#",
+        "/backends'; DROP TABLE secrets;#",
+        "/backends\\",
+    ])
+    def test_rejects_anything_with_sql_metacharacters(self, value):
+        with pytest.raises(ValueError):
+            validate_proc_path(value)
+
+
+class TestValidateQueryUuid:
+    def test_accepts_documented_format(self):
+        uuid = "550e8400-e29b-41d4-a716-446655440000"
+        assert validate_query_uuid(uuid) == uuid
+
+    @pytest.mark.parametrize("value", [
+        "x' UNION SELECT password FROM mysql.user#",
+        "550e8400-e29b-41d4-a716-44665544000",  # one digit short
+        "not-a-uuid",
+    ])
+    def test_rejects_anything_else(self, value):
+        with pytest.raises(ValueError):
+            validate_query_uuid(value)
+
+
+def _mock_db_client():
+    captured = []
+
+    def fake_execute(query, *args, **kwargs):
+        captured.append(query)
+        result = MagicMock()
+        result.to_string.return_value = "<ok>"
+        return result
+
+    client = MagicMock()
+    client.execute = fake_execute
+    return client, captured
+
+
+class TestServerResourceAndToolGuards:
+    """The four fault sites named in issue #33 must reject a malicious value
+    before db_client.execute is ever called, and must still build the exact
+    same SQL as before for a legitimate value."""
+
+    def setup_method(self):
+        self.original_db_client = server.db_client
+        server.db_client, self.captured = _mock_db_client()
+
+    def teardown_method(self):
+        server.db_client = self.original_db_client
+
+    def test_get_table_schema_rejects_malicious_table(self):
+        with pytest.raises(ValueError):
+            server.get_table_schema(db="mydb", table="x`; DROP TABLE secrets;#")
+        assert self.captured == []
+
+    def test_get_table_schema_legitimate(self):
+        server.get_table_schema(db="mydb", table="mytable")
+        assert self.captured == ["SHOW CREATE TABLE mydb.mytable"]
+
+    def test_get_database_tables_rejects_malicious_db(self):
+        with pytest.raises(ValueError):
+            server.get_database_tables(db="mydb; DROP TABLE secrets;#")
+        assert self.captured == []
+
+    def test_get_database_tables_legitimate(self):
+        server.get_database_tables(db="mydb")
+        assert self.captured == ["SHOW TABLES FROM mydb"]
+
+    def test_get_system_internal_information_rejects_malicious_path(self):
+        with pytest.raises(ValueError):
+            server.get_system_internal_information(path="x' UNION SELECT password FROM mysql.user#")
+        assert self.captured == []
+
+    def test_get_system_internal_information_legitimate(self):
+        server.get_system_internal_information(path="/backends")
+        assert self.captured == ["show proc '/backends'"]
+
+    def test_analyze_query_rejects_malicious_uuid(self):
+        with pytest.raises(ValueError):
+            server.analyze_query(uuid="x' UNION SELECT password FROM mysql.user#")
+        assert self.captured == []
+
+    def test_analyze_query_legitimate(self):
+        server.analyze_query(uuid="550e8400-e29b-41d4-a716-446655440000")
+        assert self.captured == ["ANALYZE PROFILE FROM '550e8400-e29b-41d4-a716-446655440000'"]
+
+
+class TestDbSummaryManagerGuard:
+    def test_get_database_summary_rejects_malicious_database_before_any_sql(self):
+        client, captured = _mock_db_client()
+        manager = DatabaseSummaryManager(client)
+        result = manager.get_database_summary("mydb' UNION SELECT password FROM mysql.user#", refresh=True)
+        assert captured == []
+        assert result.startswith("Error:")
+
+    def test_get_database_summary_legitimate(self):
+        client, captured = _mock_db_client()
+
+        def fake_execute(query, *args, **kwargs):
+            captured.append(query)
+            result = MagicMock()
+            result.success = True
+            result.rows = [["mytable", "1.0KB", "3"]] if query == "SHOW DATA" else []
+            return result
+
+        client.execute = fake_execute
+        manager = DatabaseSummaryManager(client)
+        manager.get_database_summary("mydb", refresh=True)
+        assert captured[0] == "SHOW DATA"


### PR DESCRIPTION
Several MCP resources and tools build SQL text with an f-string and interpolate a caller-supplied value with no validation: `db`/`table` in `SHOW CREATE TABLE` and `SHOW TABLES FROM` (`server.py`), `path` in `show proc '...'`, `uuid` in `ANALYZE PROFILE FROM '...'`, and `database` in the `db_summary` column-info query (`db_summary_manager.py`). None of these values is escaped or checked against the shape StarRocks expects, so a value containing SQL metacharacters reaches the statement text unchanged.

This adds three narrow validators (`validate_sql_identifier`, `validate_proc_path`, `validate_query_uuid` in `db_client.py`) and calls them at each of these call sites before the value is used to build a query. A database/table name must match a plain SQL identifier, a proc path is restricted to path-shaped characters, and a query UUID must match the `8-4-4-4-12` hex format the tool's own field description already documents. Invalid input now raises `ValueError` before any SQL is built, matching this codebase's existing convention for input validation (`db_client.py`, `server.py` already raise `ValueError` for other bad input).

`analyze_query`'s optional `db` parameter is validated too, since it is passed straight through to the same function's SQL-building call.

Table names read back from `SHOW TABLES FROM` inside `db_summary_manager.py` are not re-validated in this PR; they originate from the server's own listing for the database that is now validated at the entry point (`get_database_summary`), not from the caller directly.

Fixes #33

## Verification

- New test `tests/test_sql_identifier_validation.py`: fails to even import on `main` (`ValueError` helpers do not exist yet); on this branch, 30/30 pass in a clean `python:3.11-slim` container, covering the three validators plus each of the five call sites (malicious input rejected before `db_client.execute` runs, legitimate input still builds the exact same SQL as before).
- Confirmed with a throwaway pre-fix repro against unmodified `main` in the same container that the malicious inputs reach the built SQL text unguarded at all five sites, before adding the fix.
- Ran the full existing suite that does not require a live cluster (`tests/test_ssl_options.py`, `tests/test_db_client.py` under `STARROCKS_DUMMY_TEST=1`): pass/fail set is identical before and after this diff (14 pre-existing `to_string()`-format failures unrelated to this change, present on `main` too).
- Not verified against a live StarRocks cluster; `tests/test_db_client.py`'s connection-dependent cases were not run.
