### PR TITLE
Add Docker image build support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+.github
+.venv
+.pytest_cache
+__pycache__
+*.pyc
+*.pyo
+*.egg-info
+build
+dist
+wheels
+.DS_Store
+.idea
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    PATH="/app/.venv/bin:${PATH}"
+
+WORKDIR /app
+
+RUN pip install --no-cache-dir uv
+
+COPY pyproject.toml README.md LICENSE ./
+COPY src ./src
+
+RUN uv sync --no-dev
+
+EXPOSE 8000
+
+CMD ["mcp-server-starrocks", "--mode", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -93,6 +93,44 @@ Then config the MCP like this:
 }
 ```
 
+**Using Docker:**
+
+Build the image:
+
+```bash
+docker build -t mcp-server-starrocks:local .
+```
+
+Build and push a versioned image:
+
+```bash
+docker build -t <registry>/<namespace>/mcp-starrocks:0.4.0 .
+docker push <registry>/<namespace>/mcp-starrocks:0.4.0
+```
+
+Start the server in Streamable HTTP mode:
+
+```bash
+docker run --rm -p 8000:8000 \
+  -e STARROCKS_HOST=host.docker.internal \
+  -e STARROCKS_PORT=9030 \
+  -e STARROCKS_USER=root \
+  -e STARROCKS_PASSWORD='' \
+  mcp-server-starrocks:local
+```
+
+Then configure the MCP client with:
+
+```json
+{
+  "mcpServers": {
+    "mcp-server-starrocks": {
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}
+```
+
 
 **Using `uv` with installed package (individual environment variables):**
 


### PR DESCRIPTION
Add a Dockerfile and .dockerignore for packaging the StarRocks MCP server as a container image.

Document how to build, tag, push, and run the image with Streamable HTTP transport.