### PR TITLE
fix: reject non-read-only SQL in read_query and query_and_plotly_chart

### DIFF
--- a/src/mcp_server_starrocks/db_client.py
+++ b/src/mcp_server_starrocks/db_client.py
@@ -39,6 +39,9 @@ _PROC_PATH_RE = re.compile(r"^[A-Za-z0-9_/-]*$")
 _QUERY_UUID_RE = re.compile(
     r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
 )
+_DQL_LEADING_NOISE_RE = re.compile(r"^(?:\x2d\x2d[^\n]*\n|\#[^\n]*\n|/\*.*?\*/|\s)*", re.DOTALL)
+_DQL_FIRST_WORD_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_DQL_ALLOWED_KEYWORDS = {"select", "show", "describe", "desc", "explain", "with"}
 
 
 def validate_sql_identifier(value: str, kind: str) -> str:
@@ -60,6 +63,21 @@ def validate_query_uuid(value: str) -> str:
     if not _QUERY_UUID_RE.match(value):
         raise ValueError(f"Invalid query UUID: {value!r}")
     return value
+
+
+def validate_dql_only(statement: str) -> str:
+    """Reject anything whose first keyword is not SELECT/SHOW/DESCRIBE/EXPLAIN/WITH."""
+    if not statement or not statement.strip():
+        raise ValueError("Empty query is not a read-only statement.")
+    body = _DQL_LEADING_NOISE_RE.sub("", statement, count=1)
+    match = _DQL_FIRST_WORD_RE.match(body)
+    keyword = match.group(0).lower() if match else ""
+    if keyword not in _DQL_ALLOWED_KEYWORDS:
+        raise ValueError(
+            "Only read-only statements (SELECT/SHOW/DESCRIBE/EXPLAIN/WITH) are allowed here; "
+            f"got {statement.strip()[:60]!r}"
+        )
+    return statement
 
 
 def _safe_json_value(v):

--- a/src/mcp_server_starrocks/server.py
+++ b/src/mcp_server_starrocks/server.py
@@ -47,6 +47,7 @@ from .db_client import (
     validate_sql_identifier,
     validate_proc_path,
     validate_query_uuid,
+    validate_dql_only,
 )
 from .db_summary_manager import get_db_summary_manager
 from .query_profile_analytics import (
@@ -331,7 +332,7 @@ def _get_table_details(db_name, table_name, limit=None):
 
 # tools
 
-@mcp.tool(description="Execute a SELECT query or commands that return a ResultSet. Set output_file to write the full result to disk instead of returning it inline (useful for large results)." + description_suffix)
+@mcp.tool(description="Execute a read-only SELECT/SHOW/DESCRIBE/EXPLAIN query. Set output_file to write the full result to disk instead of returning it inline (useful for large results). Use write_query for anything that mutates data." + description_suffix)
 def read_query(query: Annotated[str, Field(description="SQL query to execute")],
                db: Annotated[str|None, Field(description="database")] = None,
                output_file: Annotated[str|None, Field(
@@ -341,6 +342,7 @@ def read_query(query: Annotated[str, Field(description="SQL query to execute")],
                    description="Override file format: csv|tsv|json|jsonl. If omitted, inferred from output_file extension; defaults to csv."
                )] = None,
                ctx: Context = None) -> ToolResult:
+    validate_dql_only(query)
     logger.info(f"Executing read query: {query[:100]}{'...' if len(query) > 100 else ''}")
     result = db_client.execute(query, db=db, session_id=_safe_session_id(ctx))
     if not result.success:
@@ -576,7 +578,7 @@ def one_line_summary(text: str, limit:int=100) -> str:
     return single_line
 
 
-@mcp.tool(description="using sql `query` to extract data from database, then using python `plotly_expr` to generate a chart for UI to display" + description_suffix)
+@mcp.tool(description="using a read-only sql `query` to extract data from database, then using python `plotly_expr` to generate a chart for UI to display" + description_suffix)
 def query_and_plotly_chart(
         query: Annotated[str, Field(description="SQL query to execute")],
         plotly_expr: Annotated[
@@ -603,6 +605,7 @@ def query_and_plotly_chart(
         or just types.TextContent in case of an error or no data.
     """
     try:
+        validate_dql_only(query)
         logger.info(f'query_and_plotly_chart query:{one_line_summary(query)}, plotly:{one_line_summary(plotly_expr)} format:{format}, db:{db}')
         result = db_client.execute(query, db=db, return_format="pandas", session_id=_safe_session_id(ctx))
         errmsg = None

--- a/tests/test_dql_only_validation.py
+++ b/tests/test_dql_only_validation.py
@@ -1,0 +1,102 @@
+"""
+Unit tests for validate_dql_only and the read_query / query_and_plotly_chart
+guards that use it (issue #27): read_query executed arbitrary SQL with no
+statement-type enforcement, so an LLM agent (or a prompt injection in
+retrieved data) could mutate data through the nominally read-only tool.
+
+These tests are pure-function / mocked-db_client tests and do NOT require a
+running StarRocks cluster.
+
+Run with: pytest tests/test_dql_only_validation.py -v
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.mcp_server_starrocks.db_client import validate_dql_only
+from src.mcp_server_starrocks import server
+
+
+class TestValidateDqlOnly:
+    @pytest.mark.parametrize("value", [
+        "SELECT * FROM t",
+        "  select 1",
+        "--comment\nSELECT 1",
+        "/* block comment */ SELECT 1",
+        "SHOW TABLES",
+        "DESCRIBE t",
+        "desc t",
+        "EXPLAIN SELECT 1",
+        "WITH x AS (SELECT 1) SELECT * FROM x",
+    ])
+    def test_accepts_read_only_statements(self, value):
+        assert validate_dql_only(value) == value
+
+    @pytest.mark.parametrize("value", [
+        "INSERT INTO t VALUES (1)",
+        "UPDATE t SET a = 1",
+        "DELETE FROM t",
+        "DROP TABLE t",
+        "TRUNCATE TABLE t",
+        "CREATE TABLE t (a int)",
+        "ALTER TABLE t ADD COLUMN b int",
+        "--comment\nDELETE FROM t",
+        "",
+        "   ",
+        None,
+    ])
+    def test_rejects_anything_else(self, value):
+        with pytest.raises(ValueError):
+            validate_dql_only(value)
+
+
+def _mock_db_client():
+    captured = []
+
+    def fake_execute(query, *args, **kwargs):
+        captured.append(query)
+        result = MagicMock()
+        result.success = True
+        result.rows = []
+        result.to_string.return_value = "<ok>"
+        result.to_dict.return_value = {}
+        return result
+
+    client = MagicMock()
+    client.execute = fake_execute
+    return client, captured
+
+
+class TestReadQueryGuard:
+    def setup_method(self):
+        self.original_db_client = server.db_client
+        server.db_client, self.captured = _mock_db_client()
+
+    def teardown_method(self):
+        server.db_client = self.original_db_client
+
+    def test_rejects_write_before_execute(self):
+        with pytest.raises(ValueError):
+            server.read_query(query="DELETE FROM users")
+        assert self.captured == []
+
+    def test_allows_select(self):
+        server.read_query(query="SELECT * FROM users")
+        assert self.captured == ["SELECT * FROM users"]
+
+
+class TestQueryAndPlotlyChartGuard:
+    def setup_method(self):
+        self.original_db_client = server.db_client
+        server.db_client, self.captured = _mock_db_client()
+
+    def teardown_method(self):
+        server.db_client = self.original_db_client
+
+    def test_rejects_write_before_execute(self):
+        result = server.query_and_plotly_chart(
+            query="DROP TABLE users", plotly_expr="px.scatter(df)"
+        )
+        assert self.captured == []
+        assert result.structured_content["success"] is False


### PR DESCRIPTION
read_query and query_and_plotly_chart passed their query string straight to db_client.execute() with no check on statement type, so the "read-only" tool could run INSERT/UPDATE/DELETE/DDL just as freely as write_query. An LLM agent that misreads a task, or a prompt injection in retrieved data, can mutate data through a tool the caller believes is safe to point at untrusted input.

Added validate_dql_only next to the existing validate_sql_identifier/validate_proc_path/validate_query_uuid checks in db_client.py, and called it before execute() in both tools. It looks past leading comments/whitespace for the first keyword and requires SELECT/SHOW/DESCRIBE/EXPLAIN/WITH. write_query is untouched, that's still the mutation path.

It's a keyword allowlist, not a SQL parser, so it can't see a write hiding inside a subquery or CTE body. That matches what the reporter proposed here, a light DQL-only check rather than a full read-only mode.

While tracing every place a raw query reaches the database, I noticed two more spots with unchecked input: analyze_query's sql branch also runs whatever you pass it via EXPLAIN ANALYZE, and set_session_db interpolates db without validate_sql_identifier. Neither is in scope for this issue, happy to open separate reports if you'd like.

Added tests for the allowlist itself plus both tool call sites; the write-rejection ones fail on main since validate_dql_only doesn't exist yet there.

Fixes #27
